### PR TITLE
fix: Wrong markdown to html heading level when publishing to Zhihu (#4)

### DIFF
--- a/locales/en.ts
+++ b/locales/en.ts
@@ -99,6 +99,7 @@ export default {
         noActiveFileFound: "No active file found",
         noLeafAvailable: "No leaf available for Zhihu sides view",
         htmlToMdConvertionFailed: "HTML to Markdown conversion failed:",
+        saveUseZhihuHeadingFailed: "Failed to save useZhihuHeading setting:",
     },
     settings: {
         accountTitle: "My account",
@@ -118,5 +119,8 @@ export default {
         sendRead: "Send read to Zhihu",
         sendReadDesc:
             "Send read information to Zhihu when you click the slide view articles or answers",
+        zhihuHeading: "Use Zhihu headings",
+        zhihuHeadingDesc:
+            "If this enabled, markdown heading level will be consistent with Zhihu, and leverl >= 3 will be stronged only.",
     },
 };

--- a/locales/zh-TW.ts
+++ b/locales/zh-TW.ts
@@ -96,6 +96,7 @@ export default {
         noActiveFileFound: "未找到啟用中的檔案",
         noLeafAvailable: "沒有可用的面板用來顯示知乎內容",
         htmlToMdConvertionFailed: "HTML 轉換為 Markdown 失敗：",
+        saveUseZhihuHeadingFailed: "儲存 useZhihuHeading 設定失敗：",
     },
     settings: {
         accountTitle: "我的帳戶",
@@ -113,5 +114,8 @@ export default {
         clearImageCacheButtonText: "清除",
         sendRead: "向知乎發送已讀",
         sendReadDesc: "在您點擊左側欄的文章或回答後，向知乎發送已讀請求",
+        zhihuHeading: "使用知乎特色的標題",
+        zhihuHeadingDesc:
+            "如果啟用，那麼 markdown 的標題層次會與知乎一致，且三級以上標題僅被加粗",
     },
 };

--- a/locales/zh.ts
+++ b/locales/zh.ts
@@ -96,6 +96,7 @@ export default {
         noActiveFileFound: "未找到激活的文件",
         noLeafAvailable: "没有可用的面板用于显示知乎内容",
         htmlToMdConvertionFailed: "HTML 转 Markdown 失败：",
+        saveUseZhihuHeadingFailed: "保存 useZhihuHeading 设置失败：",
     },
     settings: {
         accountTitle: "我的账户",
@@ -113,5 +114,8 @@ export default {
         clearImageCacheButtonText: "清理",
         sendRead: "向知乎发送已读",
         sendReadDesc: "在您点击左侧栏的文章或回答后，向知乎发送已读请求",
+        zhihuHeading: "使用知乎特色的标题",
+        zhihuHeadingDesc:
+            "如果启用，那么markdown的标题层次会与知乎一致，且三级以上标题仅被加粗",
     },
 };

--- a/src/answer_service.ts
+++ b/src/answer_service.ts
@@ -56,7 +56,7 @@ export class ZhihuQuestionLinkModal extends Modal {
 export async function publishCurrentAnswer(app: App) {
     const activeFile = app.workspace.getActiveFile();
     const locale = i18n.current;
-
+    const settings = await loadSettings(app.vault);
     if (!activeFile) {
         console.error(locale.error.noActiveFileFound);
         return;
@@ -111,7 +111,10 @@ export async function publishCurrentAnswer(app: App) {
         app.vault,
         transedImgContent,
     );
-    let zhihuHTML = await render.mdToZhihuHTML(transedImgContent);
+    let zhihuHTML = await render.mdToZhihuHTML(
+        transedImgContent,
+        settings.useZhihuHeadings,
+    );
     zhihuHTML = addPopularizeStr(zhihuHTML);
 
     const patchBody = {

--- a/src/publish_service.ts
+++ b/src/publish_service.ts
@@ -17,6 +17,7 @@ const locale = i18n.current;
 export async function publishCurrentFile(app: App) {
     const activeFile = app.workspace.getActiveFile();
     const vault = app.vault;
+    const settings = await loadSettings(vault);
     if (!activeFile) {
         console.error(locale.error.noActiveFileFound);
         return;
@@ -88,7 +89,10 @@ export async function publishCurrentFile(app: App) {
         vault,
         transedImgContent,
     );
-    let zhihuHTML = await render.mdToZhihuHTML(transedImgContent);
+    let zhihuHTML = await render.mdToZhihuHTML(
+        transedImgContent,
+        settings.useZhihuHeadings,
+    );
     zhihuHTML = addPopularizeStr(zhihuHTML); // 加上推广文字
     const patchBody = {
         title: title,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -7,6 +7,7 @@ interface ZhihuSettings {
     restrictToZhihuTag: boolean;
     sendReadToZhihu: boolean;
     recommendCount: number;
+    useZhihuHeadings: boolean;
 }
 
 // Default settings in case none exist in zhihu-data.json
@@ -16,6 +17,7 @@ const DEFAULT_SETTINGS: ZhihuSettings = {
     restrictToZhihuTag: false,
     sendReadToZhihu: true,
     recommendCount: 7,
+    useZhihuHeadings: true,
 };
 
 /**

--- a/src/settings_tab.ts
+++ b/src/settings_tab.ts
@@ -224,7 +224,26 @@ export class ZhihuSettingTab extends PluginSettingTab {
                         }
                     }),
             );
-
+        // Recommend Count setting
+        new Setting(containerEl)
+            .setName(this.i18n.settings.zhihuHeading)
+            .setDesc(this.i18n.settings.zhihuHeadingDesc)
+            .addToggle((toggle) =>
+                toggle
+                    .setValue(settings.useZhihuHeadings)
+                    .onChange(async (value) => {
+                        try {
+                            await saveSettings(this.app.vault, {
+                                useZhihuHeadings: value,
+                            });
+                        } catch (e) {
+                            console.error(
+                                this.i18n.error.saveUseZhihuHeadingFailed,
+                                e,
+                            );
+                        }
+                    }),
+            );
         // // Recommend Count setting
         // new Setting(containerEl)
         // 	.setName("Recommendation Count")


### PR DESCRIPTION
Fix #4 
Add custom settings.
If `useZhihuHeadings` disabled, then do default translation.
