### PR TITLE
Add: Support for internal Zhihu links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "zhihu-obsidian",
-    "version": "0.3.3",
+    "version": "0.3.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "zhihu-obsidian",
-            "version": "0.3.3",
+            "version": "0.3.4",
             "license": "MIT",
             "dependencies": {
                 "@r4ai/remark-callout": "^0.6.2",
@@ -15,7 +15,7 @@
                 "marked": "^15.0.8",
                 "mdast-util-math": "^3.0.0",
                 "mdast-util-to-markdown": "^2.1.2",
-                "mdast-util-wiki-link": "^0.1.2",
+                "mdast-util-wiki-link": "github:dongguaguaguagua/mdast-util-wiki-link",
                 "micromark-extension-math": "github:dongguaguaguagua/micromark-extension-math",
                 "micromark-extension-wiki-link": "github:dongguaguaguagua/micromark-extension-wiki-link",
                 "qrcode": "^1.5.4",
@@ -2851,8 +2851,7 @@
         },
         "node_modules/mdast-util-wiki-link": {
             "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/mdast-util-wiki-link/-/mdast-util-wiki-link-0.1.2.tgz",
-            "integrity": "sha512-DTcDyOxKDo3pB3fc0zQlD8myfQjYkW4hazUKI9PUyhtoj9JBeHC2eIdlVXmaT22bZkFAVU2d47B6y2jVKGoUQg==",
+            "resolved": "git+ssh://git@github.com/dongguaguaguagua/mdast-util-wiki-link.git#2f54f367f23b123061ebfb6ca87387a599ae7226",
             "dependencies": {
                 "@babel/runtime": "^7.12.1",
                 "mdast-util-to-markdown": "^0.6.5"
@@ -3116,7 +3115,7 @@
         },
         "node_modules/micromark-extension-wiki-link": {
             "version": "0.0.4",
-            "resolved": "git+ssh://git@github.com/dongguaguaguagua/micromark-extension-wiki-link.git#abc44b94e615a737c949d18e1c289a25b38195f0",
+            "resolved": "git+ssh://git@github.com/dongguaguaguagua/micromark-extension-wiki-link.git#14b3ce2d5a1f00ee425601a8449c52a75683a306",
             "dependencies": {
                 "@babel/runtime": "^7.12.1"
             }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "marked": "^15.0.8",
         "mdast-util-math": "^3.0.0",
         "mdast-util-to-markdown": "^2.1.2",
-        "mdast-util-wiki-link": "^0.1.2",
+        "mdast-util-wiki-link": "github:dongguaguaguagua/mdast-util-wiki-link",
         "micromark-extension-math": "github:dongguaguaguagua/micromark-extension-math",
         "micromark-extension-wiki-link": "github:dongguaguaguagua/micromark-extension-wiki-link",
         "qrcode": "^1.5.4",

--- a/src/custom_render.ts
+++ b/src/custom_render.ts
@@ -511,7 +511,7 @@ export async function remarkMdToHTML(app: App, md: string) {
                     };
             }
         },
-
+        // Obsidian callout语法支持
         blockquote(state: any, node: any): Element {
             // 如果不存在callout，说明是普通引用块，则返回原本结果
             if (node?.data?.hProperties?.dataCallout === undefined) {
@@ -580,6 +580,8 @@ export async function remarkMdToHTML(app: App, md: string) {
                 ],
             };
         },
+        // 处理 obsidian 内链，如果内链是一篇知乎文章，则会提取链接和文件名作为知乎链接
+        // 否则就是普通的下划线文字
         wikiLink(state: any, node: WikiLinkNode): Element {
             const name = node.value;
             const mdFile = file.getFilePathFromName(app, name);
@@ -601,9 +603,9 @@ export async function remarkMdToHTML(app: App, md: string) {
             }
             return {
                 type: "element",
-                tagName: "a",
+                tagName: "u",
                 properties: {},
-                children: state.all(node),
+                children: [u("text", name)],
             };
         },
     };

--- a/src/files.ts
+++ b/src/files.ts
@@ -7,7 +7,7 @@ interface FileSearchResult {
     path: string;
 }
 
-export async function getFilePathFromName(
+export async function getImgPathFromName(
     app: App,
     fileName: string,
 ): Promise<string> {
@@ -21,7 +21,7 @@ export async function getFilePathFromName(
     const normalizedName = normalizePath(fileName.trim()).toLowerCase();
     const isPath = normalizedName.includes("/");
 
-    // 支持的图片扩展名
+    // 支持的扩展名
     const imageExtensions = [".png", ".jpg", ".jpeg", ".gif", ".bmp", ".webp"];
     const hasExtension = imageExtensions.some((ext) =>
         normalizedName.endsWith(ext),
@@ -106,4 +106,17 @@ export async function getFilePathFromName(
         );
         return matches[0].path;
     }
+}
+
+/**
+ * 通过文件名（不含扩展名.md）在整个仓库中查找文件。
+ * @param fileName 文件名，例如 "这次化债是不是意味未来大通胀？-黑桦的回答"
+ * @returns TFile 对象或 null
+ */
+export function getFilePathFromName(app: App, fileName: string): TFile | null {
+    const allFiles = app.vault.getMarkdownFiles();
+    const targetFile = allFiles.find(
+        (file: TFile) => file.basename === fileName,
+    );
+    return targetFile || null;
 }

--- a/src/image_service.ts
+++ b/src/image_service.ts
@@ -8,7 +8,7 @@ import * as file from "./files";
 import { loadSettings } from "./settings";
 import i18n, { type Lang } from "../locales";
 import { App } from "obsidian";
-const locale = i18n.current;
+const locale: Lang = i18n.current;
 
 async function getImgIdFromHash(vault: Vault, imgHash: string) {
     try {
@@ -57,7 +57,7 @@ export async function uploadCover(app: App, cover: string) {
         return;
     } else {
         const imgName = match[1];
-        const imgLink = await file.getFilePathFromName(app, imgName);
+        const imgLink = await file.getImgPathFromName(app, imgName);
         const imgBuffer = fs.readFileSync(imgLink);
         const imgOriginalPath = await getZhihuImgLink(app.vault, imgBuffer);
         return imgOriginalPath;

--- a/src/types/mdast-util-wiki-link.d.ts
+++ b/src/types/mdast-util-wiki-link.d.ts
@@ -1,0 +1,1 @@
+declare module "mdast-util-wiki-link";

--- a/src/types/micromark-extension-wiki-link.d.ts
+++ b/src/types/micromark-extension-wiki-link.d.ts
@@ -1,3 +1,4 @@
 declare module "micromark-extension-wiki-link" {
-    function syntax(opts?: any): any;
+    function wikiLink(opts?: any): any;
+    function wikiImgLink(opts?: any): any;
 }


### PR DESCRIPTION
Fixes #28 
* 增加了对于 `[[...]]` 内链的识别
* 如果内链恰好是一篇知乎文章，则会提取 frontmatter 中的 zhihu-link 作为链接，文件名则为链接名。
* 如果内链找不到，或者不是一篇知乎文章，则发出去的内容就是普通的下划线文章，没有链接。